### PR TITLE
Small fix for demo server url

### DIFF
--- a/Rocket.Chat.iOS/AppDelegate.swift
+++ b/Rocket.Chat.iOS/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var centerContainer : MMDrawerController?
   
     var meteorClient = initialiseMeteor("pre2", "ws://localhost:4000/websocket");
-//    var meteorClient = initialiseMeteor("pre2", "https://demo.rocket.chat/home/websocket");
+//    var meteorClient = initialiseMeteor("pre2", "https://demo.rocket.chat/websocket");
 
   
   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {


### PR DESCRIPTION
Forgot to remove /home from the url in inittialiseMeteor for the demo server - Now it's ok
